### PR TITLE
Change command wrapping to get w1070 working

### DIFF
--- a/pyjector/projector_configs/benq.json
+++ b/pyjector/projector_configs/benq.json
@@ -1,6 +1,6 @@
 {
-    "left_surround": "\r\n*",
-    "right_surround": "#\r\n",
+    "left_surround": "\r*",
+    "right_surround": "#\r",
     "seperator": "=",
     "wait_time": 1,
     "command_failed_message": "*Block item#",


### PR DESCRIPTION
The left and right surround parameter included \r\n which doesn't work correctly with Benq w1070. This changes that to only include \r which works fine.

I'm not sure if there are other Benq devices out there that actually expects \r\n, so that we should write another model file, or if this can be applied as is.

When we run this we can see that the first character received in the response is '>'. This is ASCII 0x3e and is actually a response code. 

```
kll@PompousTheather:~/pyjector$ ./pyjector_controller -v benq /dev/ttyUSB0 power status
1445271538.029446 INFO send: '\r*pow=?#\r'
1445271539.032583 INFO recv: '>*pow=?#\r\r\n*POW=OFF#\r\n'
```

According to the manual the correct workflow would be something like 
- send \r
- wait for response, either 0x3e (positive) or 0xd,0xa (negative)
- if positive response, send the actual command
- get response

But this works good enough for most, including myself :)
